### PR TITLE
https://onpay.io/docs/technical/api_v1.html#create-new-transaction-fr…

### DIFF
--- a/OnPayClient/Models/Decorators/AtomicResponseDecorator.cs
+++ b/OnPayClient/Models/Decorators/AtomicResponseDecorator.cs
@@ -8,12 +8,12 @@ namespace OnPayClient.Models.Decorators
 {
     static class AtomicResponseDecorator
     {
-        internal static AtomicResponse<T> DecorateResponse<T>(IRestResponse<AtomicResponse<T>> response, RestClient client) where T:BaseModel
+        internal static AtomicResponse<T> DecorateResponse<T>(IRestResponse<AtomicResponse<T>> response, RestClient client) where T : BaseModel
         {
             if (response.StatusCode == HttpStatusCode.NotFound || response.Data == null)
                 return null;
 
-            if (response.StatusCode != HttpStatusCode.OK)
+            if (!response.IsSuccessful)
                 throw new InvalidServerResponseException { HttpStatus = response.StatusCode, Content = response.Content };
 
             var atomicResponse = response.Data;

--- a/OnPayClient/Models/Decorators/PagedResponseDecorator.cs
+++ b/OnPayClient/Models/Decorators/PagedResponseDecorator.cs
@@ -14,7 +14,7 @@ namespace OnPayClient.Models.Decorators
             if (response.StatusCode == HttpStatusCode.NotFound || response.Data == null)
                 return null;
 
-            if (response.StatusCode != HttpStatusCode.OK)
+            if (!response.IsSuccessful)
                 throw new InvalidServerResponseException { HttpStatus = response.StatusCode, Content = response.Content };
 
             var pagedResponse = response.Data;


### PR DESCRIPTION
e.g. here
https://onpay.io/docs/technical/api_v1.html#create-new-transaction-from-subscription

201 Created is returned, which results in an InvalidServerResponseException

The response decorators should allow all HTTP success codes
https://docs.microsoft.com/en-us/uwp/api/windows.web.http.httpresponsemessage.issuccessstatuscode